### PR TITLE
Sanitize uses of global php variables

### DIFF
--- a/duo_universal_authentication.php
+++ b/duo_universal_authentication.php
@@ -87,7 +87,9 @@ class DuoUniversalWordpressPlugin
 
     function get_page_url()
     {
-        $https_explicitly_enabled = (!empty($_SERVER['HTTPS']) && $this->duo_utils->sanitize_alphanumeric($_SERVER['HTTPS']) != 'off');
+        // todo: doc the behavior here. docs say "non-empty means HTTPS", but for IIS it will set it to "off" if HTTPS is off
+        // should also strtolower() the "off" check
+        $https_explicitly_enabled = (!empty($_SERVER['HTTPS']) && $this->wordpress_helper->sanitize_text_field($_SERVER['HTTPS']) != 'off');
         $port = absint($_SERVER['SERVER_PORT']);
         $protocol = ($https_explicitly_enabled || $port == 443) ? "https://" : "http://";
         return $this->wordpress_helper->sanitize_url($protocol.$_SERVER['HTTP_HOST'].$this->duo_utils->duo_get_uri(), ["http", "https"]);
@@ -154,10 +156,10 @@ class DuoUniversalWordpressPlugin
             $this->duo_debug_log('Doing secondary auth');
 
             // Get authorization token to trade for 2FA
-            $code = $this->duo_utils->sanitize_alphanumeric($_GET["duo_code"]);
+            $code = $this->wordpress_helper->sanitize_text_field($_GET["duo_code"]);
 
             // Get state to verify consistency and originality
-            $state = $this->duo_utils->sanitize_alphanumeric($_GET["state"]);
+            $state = $this->wordpress_helper->sanitize_text_field($_GET["state"]);
 
             // Retrieve the previously stored state and username from the session
             $associated_user = $this->get_username_from_oidc_state($state);

--- a/duo_universal_settings.php
+++ b/duo_universal_settings.php
@@ -37,7 +37,7 @@ class Settings {
         }
 
         foreach ($options as $opt=>$value) {
-            $options[$opt] = $this->duo_utils->sanitize_alphanumeric($value);
+            $options[$opt] = $this->wordpress_helper->sanitize_text_field($value);
         }
         return $options;
     }
@@ -244,22 +244,22 @@ class Settings {
 
     function duo_update_mu_options() {
         if(isset($_POST['duo_client_id'])) {
-            $client_id = $this->duo_utils->sanitize_alphanumeric($_POST['duo_client_id']);
+            $client_id = $this->wordpress_helper->sanitize_text_field($_POST['duo_client_id']);
             $result = $this->wordpress_helper->update_site_option('duo_client_id', $client_id);
         }
 
         if(isset($_POST['duo_client_secret'])) {
-            $client_secret = $this->duo_utils->sanitize_alphanumeric($_POST['duo_client_secret']);
+            $client_secret = $this->wordpress_helper->sanitize_text_field($_POST['duo_client_secret']);
             $result = $this->wordpress_helper->update_site_option('duo_client_secret', $client_secret);
         }
 
         if(isset($_POST['duo_host'])) {
-            $host = $this->wordpress_helper->sanitize_url($_POST['duo_host'], ["https"]);
+            $host = $this->wordpress_helper->sanitize_text_field($_POST['duo_host']);
             $result = $this->wordpress_helper->update_site_option('duo_host', $host);
         }
 
         if(isset($_POST['duo_failmode'])) {
-            $failmode = $this->duo_utils->sanitize_alphanumeric($_POST['duo_failmode']);
+            $failmode = $this->wordpress_helper->sanitize_text_field($_POST['duo_failmode']);
             $result = $this->wordpress_helper->update_site_option('duo_failmode', $failmode);
         } else {
             $result = $this->wordpress_helper->update_site_option('duo_failmode', "open");
@@ -274,7 +274,7 @@ class Settings {
         }
 
         if(isset($_POST['duo_xmlrpc'])) {
-            $xmlrpc = $this->duo_utils->sanitize_alphanumeric($_POST['duo_xmlrpc']);
+            $xmlrpc = $this->wordpress_helper->sanitize_text_field($_POST['duo_xmlrpc']);
             $result = $this->wordpress_helper->update_site_option('duo_xmlrpc', $xmlrpc);
         }
         else {

--- a/duo_universal_utilities.php
+++ b/duo_universal_utilities.php
@@ -110,19 +110,6 @@ class Utilities
             error_log('Duo debug: ' . $message);
         }
     }
-
-    /**
-     * Sanitize alphanumeric keys. Similar to sanitize_key(), but preserves
-     * case and disallows hyphens and underscores.
-     */
-    function sanitize_alphanumeric( $key ) {
-        $sanitized_key = '';
-
-        if ( is_scalar( $key ) ) {
-            $sanitized_key = preg_replace( '/[^a-zA-Z0-9]/', '', $key );
-        }
-        return $this->wordpress_helper->apply_filters( 'sanitize_alphanumeric', $sanitized_key, $key );
-    }
 }
 
 ?>

--- a/duo_universal_wordpress_helper.php
+++ b/duo_universal_wordpress_helper.php
@@ -36,7 +36,8 @@ interface WordpressHelperInterface
     public function esc_attr_e($text, $domain='default');
     public function esc_attr($text);
     public function translate($text, $domain='default');
-    public function sanitize_url(string $url, $protocols = null);
+    public function sanitize_url($url, $protocols = null);
+    public function sanitize_text_field($str);
 };
 
 class WordpressHelper implements WordpressHelperInterface
@@ -176,5 +177,9 @@ class WordpressHelper implements WordpressHelperInterface
     public function sanitize_url($url, $protocols = null)
     {
         return sanitize_url($url, $protocols);
+    }
+    public function sanitize_text_field($str)
+    {
+        return sanitize_text_field($str);
     }
 }

--- a/tests/duoUniversalSettingsTest.php
+++ b/tests/duoUniversalSettingsTest.php
@@ -18,13 +18,8 @@ final class SettingsTest extends TestCase
         // don't have the wordpress methods in scope
         $this->helper->method('apply_filters')->willReturnArgument(1);
         $this->helper->method('sanitize_url')->willReturnArgument(0);
-        $this->duo_utils = $this->getMockBuilder(Duo\DuoUniversalWordpress\Utilities::class)
-                                ->disableOriginalConstructor()
-                                ->disableOriginalClone()
-                                ->disableArgumentCloning()
-                                ->disallowMockingUnknownTypes()
-                                ->setMethodsExcept(['sanitize_alphanumeric'])
-                                ->getMock();
+        $this->helper->method('sanitize_text_field')->willReturnArgument(0);
+        $this->duo_utils = $this->createMock(Duo\DuoUniversalWordpress\Utilities::class);
         $this->duo_utils->wordpress_helper = $this->helper;
     }
 
@@ -533,24 +528,24 @@ final class SettingsTest extends TestCase
             "Author" => "author",
         );
         $_POST = array(
-            'duo_client_id' => 'DIAAAAAAAAAAAAAAAAAA',
-            'duo_client_secret' => 'aBcD123s3cr3t4uandme',
+            'duo_client_id' => 'mock_id',
+            'duo_client_secret' => 'mock_secret',
             'duo_host' => 'mock_host',
-            'duo_failmode' => 'mockfailmode',
+            'duo_failmode' => 'mock_failmode',
             'duo_roles' => $duo_roles,
-            'duo_xmlrpc' => 'mockxmlrpc'
+            'duo_xmlrpc' => 'mock_xmlrpc'
         );
 
         $this->helper
             ->expects($this->exactly(6))
             ->method('update_site_option')
             ->withConsecutive(
-                ['duo_client_id', 'DIAAAAAAAAAAAAAAAAAA'],
-                ['duo_client_secret', 'aBcD123s3cr3t4uandme'],
+                ['duo_client_id', 'mock_id'],
+                ['duo_client_secret', 'mock_secret'],
                 ['duo_host', 'mock_host'],
-                ['duo_failmode', 'mockfailmode'],
+                ['duo_failmode', 'mock_failmode'],
                 ['duo_roles', $duo_roles],
-                ['duo_xmlrpc', 'mockxmlrpc'],
+                ['duo_xmlrpc', 'mock_xmlrpc'],
             );
         $settings = new Duo\DuoUniversalWordpress\Settings($this->duo_utils);
         $settings->duo_update_mu_options();
@@ -572,28 +567,6 @@ final class SettingsTest extends TestCase
             );
         $settings = new Duo\DuoUniversalWordpress\Settings($this->duo_utils);
         $settings->duo_update_mu_options();
-    }
-
-    /**
-     * Test that sanitize_roles sanitizes each role via sanitize_alphanumeric
-     */
-    public function testSanitizeRoles(): void
-    {
-        $helper = $this->createMock(Duo\DuoUniversalWordpress\WordpressHelper::class);
-        $helper->method('apply_filters')->willReturnArgument(1);
-        $duo_utils = new Duo\DuoUniversalWordpress\Utilities($helper);
-        $settings = new Duo\DuoUniversalWordpress\Settings($duo_utils);
-
-        $duo_roles = array(
-            "Editor" => "editor_1",
-            "Author" => "Author_!2",
-        );
-        $result = $settings->sanitize_roles($duo_roles);
-
-        $this->assertEquals($result, array(
-            "Editor" => "editor1",
-            "Author" => "Author2",
-        ));
     }
 
 }

--- a/tests/duoUniversalUtilitiesTest.php
+++ b/tests/duoUniversalUtilitiesTest.php
@@ -176,32 +176,4 @@ final class UtilitiesTest extends TestCase
         $duo_utils = new Duo\DuoUniversalWordpress\Utilities($helper);
         $this->assertEquals($duo_utils->duo_get_option("test"), 'value');
     }
-
-    /**
-     * Test that sanitize_alphanumeric preserves case and removes all
-     * non-alphanumeric characters
-     */
-    public function testSanitizeAlphanumeric(): void
-    {
-        $helper = $this->createMock(Duo\DuoUniversalWordpress\WordpressHelper::class);
-        $helper->method('apply_filters')->willReturnArgument(1);
-        $duo_utils = new Duo\DuoUniversalWordpress\Utilities($helper);
-
-        $test_string = 'aBc-123_$%^';
-        $this->assertEquals($duo_utils->sanitize_alphanumeric($test_string), 'aBc123');
-    }
-
-    /**
-     * Test that sanitize_alphanumeric returns an empty string for
-     * non-scalar values
-     */
-    public function testSanitizeAlphanumericNonScalar(): void
-    {
-        $helper = $this->createMock(Duo\DuoUniversalWordpress\WordpressHelper::class);
-        $helper->method('apply_filters')->willReturnArgument(1);
-        $duo_utils = new Duo\DuoUniversalWordpress\Utilities($helper);
-
-        $test_value = ['arrays are not scalar'];
-        $this->assertEquals($duo_utils->sanitize_alphanumeric($test_value), '');
-    }
 }


### PR DESCRIPTION
## Description
Wordpress requires all usages of PHP global variables (e.g. `_GET`, `_SERVER`, etc.) to be sanitized before use and ASAP. This PR 

## Motivation and Context
We won't pass wordpress plugin review without this.

## How Has This Been Tested?
TBD. I'm not yet sure the best way to test this. Maybe by setting it up manually? It will be tested before merging.

## Types of Changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
