### PR TITLE
Avoid login loop by allowing users to authenticate with emails as well as username

### DIFF
--- a/duo_universal_authentication.php
+++ b/duo_universal_authentication.php
@@ -213,6 +213,11 @@ class DuoUniversal_WordpressPlugin
             $this->wordpress_helper->remove_action('authenticate', 'wp_authenticate_username_password', 20);
             $user = $this->wordpress_helper->wp_authenticate_username_password(null, $username, $password);
             if (!is_a($user, 'WP_User')) {
+                // maybe we got an email
+                $user = $this->wordpress_helper->wp_authenticate_email_password(null, $username, $password );
+            }
+
+            if (!is_a($user, 'WP_User')) {
                 // on error, return said error (and skip the remaining plugin chain)
                 return $user;
             } else {

--- a/duo_universal_wordpress_helper.php
+++ b/duo_universal_wordpress_helper.php
@@ -13,6 +13,7 @@ interface DuoUniversal_WordpressHelperInterface
     public function WP_User($id, $name='', $site_id='');
     public function remove_action($hook_name, $callback, $priority);
     public function wp_authenticate_username_password($user, $username, $password);
+    public function wp_authenticate_email_password($user, $email, $password);
     public function is_multisite();
     public function get_current_site();
     public function is_user_logged_in();
@@ -81,6 +82,10 @@ class DuoUniversal_WordpressHelper implements DuoUniversal_WordpressHelperInterf
     public function wp_authenticate_username_password($user, $username, $password)
     {
         return wp_authenticate_username_password($user, $username, $password);
+    }
+    public function wp_authenticate_email_password($user, $email, $password)
+    {
+        return wp_authenticate_email_password($user, $email, $password);
     }
     public function is_multisite()
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Wordpress added the ability to login with email in wordpress 4.5.0 but the Duo plugins have never
properly supported this behavior. Now instead of assuming something went wrong during authentication
when an email is provided we use the wordpress email authentication method to see if we get a valid
user back and proceed with that user object if it's successful.

## Motivation and Context
We were getting weird login loop behavior where secondary auth was flagged as failing even after it
was completed which kicked users back to the login screen creating a sort of login-loop experience.

## How Has This Been Tested?
New unit tests added to check for email case. Manually tested email logins and username logins.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
