### PR TITLE
Logout rather than 2FA when Duo session expires

### DIFF
--- a/class-duouniversal-wordpressplugin.php
+++ b/class-duouniversal-wordpressplugin.php
@@ -274,7 +274,7 @@ class DuoUniversal_WordpressPlugin {
 			if ( $this->duo_utils->duo_role_require_mfa( $user ) && ! $this->duo_verify_auth_status( $user->user_login ) ) {
 				\wp_logout();
 				wp_redirect( wp_login_url() );
-				exit();
+				$this->exit();
 			}
 			$this->duo_debug_log( "User $user->user_login allowed" );
 		}


### PR DESCRIPTION
- Force logout rather than 2FA is Duo session expires independent from 2FA

## Description
Previously when your Duo session expires and your WordPress session is still valid you would end
up in a state where you'd do a 2FA but when get kicked backed to the login screen and have to
do 1st and 2nd factor over again. Now we just cut to the chase and log you out.

## Motivation and Context
Bug fix

## How Has This Been Tested?
I've manually tested this flow by clearing transients while using the wordpress site.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
