### PR TITLE
Add stable tag

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,7 @@
 Contributors: duosecurity
 Tags: authentication, muti-factor, two-factor, authenticator, login, username, password, duo, security
 Requires at least: 6.0.0
+Stable tag: 1.0.0
 Tested up to: 6.4.3
 Requires PHP: 7.3.16
 License: Apache-2.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
WordPress requires us to have a "Stable tag" in our readme that matches the vesrino of the plugin.

## Motivation and Context
This change is made for the WordPress review

## How Has This Been Tested?
Text only change
