### PR TITLE
Remove variable concat str

### DIFF
--- a/class-duouniversal-wordpressplugin.php
+++ b/class-duouniversal-wordpressplugin.php
@@ -147,7 +147,7 @@ class DuoUniversal_WordpressPlugin {
 			if ( isset( $_GET['error'] ) ) {
 				$error = $this->duo_utils->new_WP_Error(
 					'Duo authentication failed',
-					\__( 'ERROR: Error during login, please contact your system administrator.')
+					\__( 'ERROR: Error during login; please contact your system administrator.')
 				);
 
 				$error_msg = \sanitize_text_field( wp_unslash( $_GET['error'] ) );

--- a/tests/duoUniversalAuthenticationTest.php
+++ b/tests/duoUniversalAuthenticationTest.php
@@ -277,7 +277,7 @@ final class authenticationTest extends WPTestCase
             ->addMethods(["get_error_message"])
             ->getMock();
         $this->duo_utils->method('duo_auth_enabled')->willReturn(true);
-        $this->duo_utils->method('new_WP_Error')->willReturn($error)->with("Duo authentication failed", "ERROR: Error during login, please contact your system administrator.");
+        $this->duo_utils->method('new_WP_Error')->willReturn($error)->with("Duo authentication failed", "ERROR: Error during login; please contact your system administrator.");
         $authentication->expects($this->once())->method('duo_debug_log')->with($this->equalTo("test error: test description"));
         WP_Mock::passthruFunction('__');
         WP_Mock::passthruFunction('wp_unslash');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
WP require string not concat with variable for internationalization reason.
That means we can not display error that reported from admin panel.
We have to display an generic error when we receive error from admin panel
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Per requirements from WP
## How Has This Been Tested?
<!--- Please describe how you tested your changes, or what tests were added -->
Not tested
## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
