### PR TITLE
Add missing unslash calls

### DIFF
--- a/class-duouniversal-utilities.php
+++ b/class-duouniversal-utilities.php
@@ -83,23 +83,20 @@ class DuoUniversal_Utilities {
 		// paths (for which protocols are not required/enforced), and REQUEST_URI
 		// always includes the leading slash in the URI path.
 		if ( ! isset( $_SERVER['REQUEST_URI'] )
-            // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-			|| ( ! empty( $_SERVER['QUERY_STRING'] ) && ! strpos( \sanitize_url( $_SERVER['REQUEST_URI'] ), '?', 0 ) )
+			|| ( ! empty( $_SERVER['QUERY_STRING'] ) && ! strpos( \sanitize_url( \wp_unslash( $_SERVER['REQUEST_URI'] ) ), '?', 0 ) )
 		) {
 			if ( ! isset( $_SERVER['PHP_SELF'] ) ) {
 				throw new Exception( 'Could not determine request URI' );
 			}
-            // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-			$current_uri = isset( $_SERVER['PHP_SELF'] ) ? substr( \sanitize_url( $_SERVER['PHP_SELF'] ), 1 ) : null;
+			$current_uri = isset( $_SERVER['PHP_SELF'] ) ? substr( \sanitize_url( \wp_unslash( $_SERVER['PHP_SELF'] ) ), 1 ) : null;
 			if ( isset( $_SERVER['QUERY_STRING'] ) ) {
-                // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-				$current_uri = \sanitize_url( $current_uri . '?' . $_SERVER['QUERY_STRING'] );
+				$current_uri = \sanitize_url( $current_uri . '?' . \wp_unslash( $_SERVER['QUERY_STRING'] ) );
 			}
 
 			return $current_uri;
 		} else {
             // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-			return \sanitize_url( $_SERVER['REQUEST_URI'] );
+			return \sanitize_url( \wp_unslash( $_SERVER['REQUEST_URI'] ) );
 		}
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`wp_unslash` only removes _backslashes_ contrary to what the name suggests. It's just a wrapper
around https://www.php.net/manual/en/function.stripslashes.php if you're curious what the exact
behavior is. As such this function should be safe to use with URLs

## Motivation and Context
We want to handle data safely which, in WordPress land means unslashing variables.

## How Has This Been Tested?
Manually verified it doesn't break plugin behavior. Also unit tests still pass

## Are there any XKCD references?
https://xkcd.com/727/
