### PR TITLE
Add nonce check to multisite option update

### DIFF
--- a/class-duouniversal-settings.php
+++ b/class-duouniversal-settings.php
@@ -270,6 +270,8 @@ class DuoUniversal_Settings {
 	}
 
 	function duo_update_mu_options() {
+		check_admin_referer( 'siteoptions' );
+
 		if ( isset( $_POST['duoup_client_id'] ) ) {
 			$client_id = $this->duoup_client_id_validate( sanitize_text_field( \wp_unslash( $_POST['duoup_client_id'] ) ) );
 			$result    = \update_site_option( 'duoup_client_id', $client_id );

--- a/tests/duoUniversalSettingsTest.php
+++ b/tests/duoUniversalSettingsTest.php
@@ -578,6 +578,7 @@ final class SettingsTest extends WPTestCase
         WP_Mock::userFunction('update_site_option')->once()->with('duoup_failmode', 'closed');
         WP_Mock::userFunction('update_site_option')->once()->with('duoup_roles', $duoup_roles);
         WP_Mock::userFunction('update_site_option')->once()->with('duoup_xmlrpc', 'off');
+        WP_Mock::passthruFunction('check_admin_referer');
         WP_Mock::passthruFunction('wp_unslash');
 
         $settings = new Duo\DuoUniversalWordpress\DuoUniversal_Settings($this->duo_utils);
@@ -594,6 +595,7 @@ final class SettingsTest extends WPTestCase
         WP_Mock::userFunction('update_site_option')->once()->with('duoup_failmode', 'open');
         WP_Mock::userFunction('update_site_option')->once()->with('duoup_roles', []);
         WP_Mock::userFunction('update_site_option')->once()->with('duoup_xmlrpc', 'on');
+        WP_Mock::passthruFunction('check_admin_referer');
 
         $settings = new Duo\DuoUniversalWordpress\DuoUniversal_Settings($this->duo_utils);
         $settings->duo_update_mu_options();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In order to securely process form data we need to verify a nonce for the form that it's coming from.
For multi-site WordPress there is already a nonce set on the form called `siteoptions`. We use that
to verify that the form update request came from the right place.

## Motivation and Context
We want to keep the page secure against replay attacks. Also this came up during the WordPress review.

## How Has This Been Tested?
This was tested by checking if the page works as expected with the nonce and breaks without it. It
was tested manually.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
