### PR TITLE
Fix error with PHP namespaces

### DIFF
--- a/duouniversal-wordpress.php
+++ b/duouniversal-wordpress.php
@@ -26,8 +26,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-defined( 'ABSPATH' ) || die( 'Direct Access Denied' );
-
 require_once 'class-duouniversal-settings.php';
 require_once 'class-duouniversal-utilities.php';
 require_once 'vendor/autoload.php';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We didn't include full namespace paths for two of the constructors and that caused PHP error.

## How Has This Been Tested?
Couldn't think of a good way to test this without having a large integration test. Which we might add but it's outside the scope of this PR.
