### PR TITLE
php 8 compatibilty

### DIFF
--- a/class-duouniversal-settings.php
+++ b/class-duouniversal-settings.php
@@ -21,6 +21,8 @@ require_once 'class-duouniversal-utilities.php';
 const SECRET_PLACEHOLDER = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx';
 
 class DuoUniversal_Settings {
+	public $duo_utils;
+
 	public function __construct(
 		$duo_utils
 	) {

--- a/class-duouniversal-wordpressplugin.php
+++ b/class-duouniversal-wordpressplugin.php
@@ -26,6 +26,8 @@ use Duo\DuoUniversal\Client;
 const DUO_TRANSIENT_EXPIRATION = 48 * 60 * 60;
 
 class DuoUniversal_WordpressPlugin {
+	private $duo_client;
+	public $duo_utils;
 
 	public function __construct(
 		$duo_utils,


### PR DESCRIPTION
## Description
In order to be PHP 8 compatible we need to not use deprecated dynamic properties.

## Motivation and Context
We need to either assert the highest version that we support or test with the latest version
of PHP (in this case PHP 8.3). We can work with PHP 8.3 but we need these changes first.

## How Has This Been Tested?
Manually tested on a WordPress container (wordpress:php8.3)
