### PR TITLE
Remove code to workaround old IIS behavior

### DIFF
--- a/class-duouniversal-settings.php
+++ b/class-duouniversal-settings.php
@@ -226,8 +226,8 @@ class DuoUniversal_Settings {
 	}
 
 	function duoup_add_settings_field( $id, $title, $callback, $sanitize_callback ) {
-	    \add_settings_field( $id, $title, $callback, 'duo_universal_settings', 'duo_universal_settings', array( 'label_for' => $id ) );
-	    \register_setting( 'duo_universal_settings', $id, $sanitize_callback );
+		\add_settings_field( $id, $title, $callback, 'duo_universal_settings', 'duo_universal_settings', array( 'label_for' => $id ) );
+		\register_setting( 'duo_universal_settings', $id, $sanitize_callback );
 	}
 
 
@@ -247,7 +247,7 @@ class DuoUniversal_Settings {
 			$this->duo_add_site_option( 'duoup_roles', $allroles );
 			$this->duo_add_site_option( 'duoup_xmlrpc', 'off' );
 		} else {
-			\add_settings_section( 'duo_universal_settings', 'Main Settings', array( $this, 'duo_settings_text' ), 'duo_universal_settings');
+			\add_settings_section( 'duo_universal_settings', 'Main Settings', array( $this, 'duo_settings_text' ), 'duo_universal_settings' );
 			$this->duoup_add_settings_field( 'duoup_client_id', 'Client ID', array( $this, 'duo_settings_client_id' ), array( $this, 'duoup_client_id_validate' ) );
 			$this->duoup_add_settings_field( 'duoup_client_secret', 'Client Secret', array( $this, 'duo_settings_client_secret' ), array( $this, 'duoup_client_secret_validate' ) );
 			$this->duoup_add_settings_field( 'duoup_api_host', 'API hostname', array( $this, 'duo_settings_host' ), array( $this, 'duoup_api_host_validate' ) );

--- a/class-duouniversal-utilities.php
+++ b/class-duouniversal-utilities.php
@@ -82,26 +82,7 @@ class DuoUniversal_Utilities {
 	}
 
 	function duo_get_uri() {
-		// Workaround for IIS which may not set REQUEST_URI, or QUERY parameters.
-		// sanitize_url can be used due to its special handling of relative
-		// paths (for which protocols are not required/enforced), and REQUEST_URI
-		// always includes the leading slash in the URI path.
-		if ( ! isset( $_SERVER['REQUEST_URI'] )
-			|| ( ! empty( $_SERVER['QUERY_STRING'] ) && ! strpos( \sanitize_url( \wp_unslash( $_SERVER['REQUEST_URI'] ) ), '?', 0 ) )
-		) {
-			if ( ! isset( $_SERVER['PHP_SELF'] ) ) {
-				throw new Exception( 'Could not determine request URI' );
-			}
-			$current_uri = isset( $_SERVER['PHP_SELF'] ) ? substr( \sanitize_url( \wp_unslash( $_SERVER['PHP_SELF'] ) ), 1 ) : null;
-			if ( isset( $_SERVER['QUERY_STRING'] ) ) {
-				$current_uri = \sanitize_url( $current_uri . '?' . \wp_unslash( $_SERVER['QUERY_STRING'] ) );
-			}
-
-			return $current_uri;
-		} else {
-            // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-			return \sanitize_url( \wp_unslash( $_SERVER['REQUEST_URI'] ) );
-		}
+		return \sanitize_url( \wp_unslash( $_SERVER['REQUEST_URI'] ) );
 	}
 
 	function duo_get_option( $key, $default_value = '' ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There was some old code carrier over from the previous plugin which worked around IIS issues at
the time. This has sense been fixed https://ruslany.net/2008/08/update-for-iis-70-fastcgi-module/
and support for the affected version ended in January of 2020. Consequently we no longer need this
code.

## Motivation and Context
Without this workaround we don't need to access or sanitize as many globals. Also we aren't mucking
around with URLs when we don't have to and it makes the scanners happier. Win, win, win.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
