### PR TITLE
Escape translated strings that are displayed in HTML elements

### DIFF
--- a/class-duouniversal-settings.php
+++ b/class-duouniversal-settings.php
@@ -290,7 +290,7 @@ class DuoUniversal_Settings {
 	}
 
 	function print_field( $id, $label, $input ) {
-		printf( "<tr><th><label for='$id'>%s</label></th><td>%s</td></tr>\n", \esc_html( $label ), $input );
+		printf( "<tr><th><label for='%s'>%s</label></th><td>%s</td></tr>\n", \esc_attr( $id ), \esc_html( $label ), $input );
 	}
 
 	function duo_mu_options() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Per the WordPress review feedback we need to be escaping strings that come out of translation
functions. I've opted to do this mostly with `esc_html__` where appropriate and opted to do
it as late as possible (e.g. in `print_field` rather than `duo_mu_options`).

## Motivation and Context
The WordPress review came back with specific complaints around us not doing this.

## How Has This Been Tested?
I have visually verified that this change hasn't broken the displaying of strings.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
