### PR TITLE
Fix debug logging

### DIFF
--- a/class-duouniversal-utilities.php
+++ b/class-duouniversal-utilities.php
@@ -94,8 +94,7 @@ class DuoUniversal_Utilities {
 	}
 
 	function duo_debug_log( $message ) {
-		global $WP_DEBUG;
-		if ( $WP_DEBUG ) {
+		if ( defined('WP_DEBUG') && true == WP_DEBUG ) {
 			error_log( 'Duo debug: ' . $message );
 		}
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In my local testing using the provided docker-compose.yml, I could not see any Duo debug messages when `WP_DEBUG` is enabled in `wp-config.php`.

I believe this is because the plugin was trying to use a `$WP_DEBUG` variable, rather than the `WP_DEBUG` constant. With this change the debugging messages are now logged.

## Motivation and Context
To fix debugging messages to help diagnose issues.

## How Has This Been Tested?
Tested locally using the provided docker-compose.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
