### PR TITLE
Fix PHP Fatal Error on Clustered Hosting Environments

### DIFF
--- a/class-duouniversal-settings.php
+++ b/class-duouniversal-settings.php
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-require_once 'class-duouniversal-utilities.php';
+require_once plugin_dir_path( __FILE__ ) . 'class-duouniversal-utilities.php';
 const SECRET_PLACEHOLDER = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx';
 
 class DuoUniversal_Settings {

--- a/class-duouniversal-wordpressplugin.php
+++ b/class-duouniversal-wordpressplugin.php
@@ -17,9 +17,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-require_once 'class-duouniversal-settings.php';
-require_once 'class-duouniversal-utilities.php';
-require_once 'vendor/autoload.php';
+require_once plugin_dir_path( __FILE__ ) . require_once 'class-duouniversal-settings.php';
+require_once plugin_dir_path( __FILE__ ) . require_once 'class-duouniversal-utilities.php';
+require_once plugin_dir_path( __FILE__ ) . require_once 'vendor/autoload.php';
 
 use Duo\DuoUniversal\Client;
 

--- a/class-duouniversal-wordpressplugin.php
+++ b/class-duouniversal-wordpressplugin.php
@@ -17,9 +17,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-require_once plugin_dir_path( __FILE__ ) . require_once 'class-duouniversal-settings.php';
-require_once plugin_dir_path( __FILE__ ) . require_once 'class-duouniversal-utilities.php';
-require_once plugin_dir_path( __FILE__ ) . require_once 'vendor/autoload.php';
+require_once plugin_dir_path( __FILE__ ) . 'class-duouniversal-settings.php';
+require_once plugin_dir_path( __FILE__ ) . 'class-duouniversal-utilities.php';
+require_once plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
 
 use Duo\DuoUniversal\Client;
 

--- a/duouniversal-wordpress.php
+++ b/duouniversal-wordpress.php
@@ -26,10 +26,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-require_once 'class-duouniversal-settings.php';
-require_once 'class-duouniversal-utilities.php';
-require_once 'vendor/autoload.php';
-require_once 'class-duouniversal-wordpressplugin.php';
+require_once plugin_dir_path( __FILE__ ) . 'class-duouniversal-settings.php';
+require_once plugin_dir_path( __FILE__ ) . 'class-duouniversal-utilities.php';
+require_once plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
+require_once plugin_dir_path( __FILE__ ) . 'class-duouniversal-wordpressplugin.php';
 
 use Duo\DuoUniversal\Client;
 use Duo\DuoUniversalWordpress;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,7 +1,7 @@
 <?php
 
 // First we need to load the composer autoloader, so we can use WP Mock
-require_once plugin_dir_path( __FILE__ ) . '/vendor/autoload.php';
+require_once plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
 
 // Bootstrap WP_Mock to initialize built-in features
 WP_Mock::bootstrap();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,7 +1,7 @@
 <?php
 
 // First we need to load the composer autoloader, so we can use WP Mock
-require_once dirname(__DIR__).'/vendor/autoload.php';
+require_once plugin_dir_path( __FILE__ ) . '/vendor/autoload.php';
 
 // Bootstrap WP_Mock to initialize built-in features
 WP_Mock::bootstrap();

--- a/tests/duoUniversalAuthenticationTest.php
+++ b/tests/duoUniversalAuthenticationTest.php
@@ -4,7 +4,7 @@ use Duo\DuoUniversal\DuoException;
 use Duo\DuoUniversalWordpress;
 use PHPUnit\Framework\TestCase;
 use WP_Mock\Tools\TestCase as WPTestCase;
-require_once 'class-duouniversal-wordpressplugin.php';
+require_once plugin_dir_path( __FILE__ ) . 'class-duouniversal-wordpressplugin.php';
 
 final class authenticationTest extends WPTestCase
 {

--- a/tests/duoUniversalSettingsTest.php
+++ b/tests/duoUniversalSettingsTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 use WP_Mock\Tools\TestCase as WPTestCase;
 use WP_Mock;
 
-require_once 'class-duouniversal-settings.php';
+require_once plugin_dir_path( __FILE__ ) . 'class-duouniversal-settings.php';
 
 final class SettingsTest extends WPTestCase
 {

--- a/tests/duoUniversalUtilitiesTest.php
+++ b/tests/duoUniversalUtilitiesTest.php
@@ -3,7 +3,7 @@
 use Duo\DuoUniversal\DuoException;
 use Duo\DuoUniversalWordpress;
 use PHPUnit\Framework\TestCase;
-require_once 'class-duouniversal-utilities.php';
+require_once plugin_dir_path( __FILE__ ) . 'class-duouniversal-utilities.php';
 
 final class UtilitiesTest extends TestCase
 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

On clustered hosting, there is a PHP fatal error due to missing files. This is caused by file paths not utilising "absolute file paths".

## Description
<!--- Describe your changes -->

This issue occurs because the file is missing in clustered hosting such as Kubernetes:

```
[18-Apr-2024 17:51:11 UTC] PHP Fatal error:  Uncaught Error: Class "Duo\DuoUniversal\Client" not found in /var/www/html/wp-content/plugins/duo-universal/duouniversal-wordpress.php:41
Stack trace:
#0 /var/www/html/wp-settings.php(398): include_once()
#1 /var/www/html/wp-config.php(274): require_once('...')
#2 /var/www/html/wp-load.php(50): require_once('...')
#3 /var/www/html/wp-login.php(12): require('...')
#4 {main}
  thrown in /var/www/html/wp-content/plugins/duo-universal/duouniversal-wordpress.php on line 41
```

The fix introduces engineering best practices to use `plugin_dir_path( __FILE__ )`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is required because it causes a fatal error on clustered hosting such as Kubernetes.
It solves the fatal error.

## How Has This Been Tested?
<!--- Please describe how you tested your changes, or what tests were added -->
1. Install WordPress on clustered hosting
1. Install and activate the plugin
3. Add the DUO credentials
4. A PHP fatal error must occur

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
