### PR TITLE
Draft: Switch from transients to options

### DIFF
--- a/class-duouniversal-wordpressplugin.php
+++ b/class-duouniversal-wordpressplugin.php
@@ -124,6 +124,9 @@ class DuoUniversal_WordpressPlugin {
 	}
 
 	function duo_start_second_factor( $user ) {
+		// Clear any existing user state to purge old DB rows
+		$this->clear_user_auth( $user );
+
 		$this->duo_client->healthCheck();
 
 		$oidc_state                     = $this->duo_client->generateState();

--- a/class-duouniversal-wordpressplugin.php
+++ b/class-duouniversal-wordpressplugin.php
@@ -43,14 +43,14 @@ class DuoUniversal_WordpressPlugin {
 	 * status: whether or not an authentication is in progress or is completed ("in-progress" or "authenticated")
 	 **/
 	function update_user_auth_status( $user, $status, $redirect_url = '', $oidc_state = null ) {
-		\set_transient( 'duo_auth_' . $user . '_status', $status, DUO_TRANSIENT_EXPIRATION );
+		\update_site_option( 'duo_auth_' . $user . '_status', $status );
 		if ( $redirect_url ) {
-			\set_transient( 'duo_auth_' . $user . '_redirect_url', $redirect_url, DUO_TRANSIENT_EXPIRATION );
+			\update_site_option( 'duo_auth_' . $user . '_redirect_url', $redirect_url );
 		}
 		if ( $oidc_state ) {
 			// we need to track the state in two places so we can clean up later.
-			\set_transient( 'duo_auth_' . $user . '_oidc_state', $oidc_state, DUO_TRANSIENT_EXPIRATION );
-			\set_transient( "duo_auth_state_$oidc_state", $user, DUO_TRANSIENT_EXPIRATION );
+			\update_site_option( 'duo_auth_' . $user . '_oidc_state', $oidc_state );
+			\update_site_option( "duo_auth_state_$oidc_state", $user );
 		}
 	}
 
@@ -59,7 +59,7 @@ class DuoUniversal_WordpressPlugin {
 	}
 
 	function get_user_auth_status( $user ) {
-		return \get_transient( 'duo_auth_' . $user . '_status' );
+		return \get_site_option( 'duo_auth_' . $user . '_status' );
 	}
 
 	function duo_verify_auth_status( $user ) {
@@ -67,22 +67,22 @@ class DuoUniversal_WordpressPlugin {
 	}
 
 	function get_username_from_oidc_state( $oidc_state ) {
-		return \get_transient( "duo_auth_state_$oidc_state" );
+		return \get_site_option( "duo_auth_state_$oidc_state" );
 	}
 
 	function get_redirect_url( $user ) {
-		return \get_transient( 'duo_auth_' . $user . '_redirect_url' );
+		return \get_site_option( 'duo_auth_' . $user . '_redirect_url' );
 	}
 
 	function clear_user_auth( $user ) {
 		$username = $user->user_login;
 		try {
-			$oidc_state = \get_transient( 'duo_auth_' . $username . '_oidc_state' );
+			$oidc_state = \get_site_option( 'duo_auth_' . $username . '_oidc_state' );
 
-			\delete_transient( 'duo_auth_' . $username . '_status' );
-			\delete_transient( 'duo_auth_' . $username . '_oidc_state' );
-			\delete_transient( "duo_auth_state_$oidc_state" );
-			\delete_transient( 'duo_auth_' . $username . '_redirect_url' );
+			\delete_site_option( 'duo_auth_' . $username . '_status' );
+			\delete_site_option( 'duo_auth_' . $username . '_oidc_state' );
+			\delete_site_option( "duo_auth_state_$oidc_state" );
+			\delete_site_option( 'duo_auth_' . $username . '_redirect_url' );
 		} catch ( \Exception $e ) {
 			// there's not much we can do but we shouldn't fail the logout because of this.
 			$this->duo_debug_log( $e->getMessage() );


### PR DESCRIPTION
One of two possible solutions to the transient caching issue.

This switches everything to options, which is largely the same behavior as transients, but without being affected by the cache, and without an expiration time.

Benefits:
- Simple change, almost 1:1 equivalent with transients API.

Downsides:
- Without any automatic expiration/cleanup, we need to be sure not to slowly fill the database will duo rows that will never be cleaned up. (Especially the `duo_auth_state_$oidc_state` one which could be orphaned and added on every login)
  - To help combat that, I added a call to `clear_user_auth` at the start of `duo_start_second_factor`. So on every future login, this will clear any existing rows and prevent "login buildup"
  - There is still one potential for buildup: If many users are created and log in, but then _never_ log out. (And then optionally deleted). Each user will have 4 db rows which are *never* removed. For standard use cases this _seems_ unlikely to be highly impactful, but wordpress continues to amaze us with its behavior... Also note, this seems to be a "common" type of issue with wordpress plugins, there are plugins designed specifically to clean out the cruft left behind from other plugins, so maybe this is just standard operating procedure?

Note: I was initially concerned that the lack of a timeout on the main `duo_auth_' . $user . '_status'` token cause any issues, e.g. now they're permanently logged (or permanently MFA'd) when they should have a 48 hour timeout, but I've verified that the timeout still works, and the primary auth process clears the status the duo status before it's checked.

(Note: Unit tests still need to be updated if we choose this solution)