### PR TITLE
Don't package dev dependencies into production plugin

### DIFF
--- a/.github/workflows/wp_ci.yml
+++ b/.github/workflows/wp_ci.yml
@@ -26,14 +26,18 @@ jobs:
           php-version: ${{ matrix.php }}
           coverage: xdebug
 
-      - name: Composer install
+      - name: Composer install prod dependencies
+        run: composer install --no-dev
+
+        # Package before installing dev dependencies so we don't include them in the production zip
+      - name: Package duo-universal
+        run: ./package.sh
+
+      - name: Composer install dev dependencies
         run: composer install
 
       - name: PHP tests
         run: ./vendor/bin/phpunit --process-isolation tests
-
-      - name: Package duo-universal
-        run: ./package.sh
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I noticed that the official plugin zip file includes many unneeded dev dependencies inside of ./vendor . This refactors the github actions to only install the production dependencies, then package them, then install the dev dependencies and test.

## Motivation and Context
This wasn't breaking anything, but takes the vendor directory from 19 dependencies down to 3. It reduces the size of the duo-universal.zip file from 3.4MB to 190KB.

## How Has This Been Tested?
I've tested this same change locally and the plugin still functions as expected.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
