### PR TITLE
Remove login session duration note in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ This plugin reaches out to Duo's MFA cloud service for the configured user roles
 For more information about Duo's privacy policy see https://duo.com/legal/cisco-online-privacy-statement
 Duo's terms of service can be found here https://duo.com/legal/terms
 
-Login sessions are affected by this plugin. The shorter duration between your WordPress and Duo timeout will determine when the session expires. Duo sessions have a timeout of 48 hours, which is not currently configurable.
 # Usage
 
 Documentation: <https://duo.com/docs/wordpress>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
After the refactoring in https://github.com/duosecurity/duo_universal_wordpress/pull/67 , there is no longer a separate 48 hour "Duo session" length because there are no transients which expire. Everything is now controlled by Wordpress sessions.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe how you tested your changes, or what tests were added -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
