### PR TITLE
Cleanup user_meta on plugin uninstall

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -36,3 +36,8 @@ delete_site_option( 'duoup_api_host' );
 delete_site_option( 'duoup_roles' );
 delete_site_option( 'duoup_failmode' );
 delete_site_option( 'duoup_xmlrpc' );
+
+// Delete Duo user_meta fields for all users
+delete_metadata( 'user', 0, 'duo_auth_status', '', true );
+delete_metadata( 'user', 0, 'duo_auth_redirect_url', '', true );
+delete_metadata( 'user', 0, 'duo_auth_oidc_state', '', true );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This removes all Duo user_meta DB fields when the plugin is uninstalled. Luckily we don't need to manually iterate over all users; the last `true` parameter to `delete_metadata` tells it to ignore the specified ID (0) and instead delete it from all matching objects https://developer.wordpress.org/reference/functions/delete_metadata/

## Motivation and Context
This wasn't "breaking" anything, but we want to follow best practices and not leave any cruft behind https://developer.wordpress.org/plugins/plugin-basics/uninstall-methods/

## How Has This Been Tested?
Manually tested in a scenario with 2 users with Duo fields present, plus 1 user without Duo fields in the DB. On uninstall, the fields for both users were removed, and there were no errors.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
