### PR TITLE
dev - Added hook to allow other plugins to provide their own authenti…

### DIFF
--- a/class-duouniversal-wordpressplugin.php
+++ b/class-duouniversal-wordpressplugin.php
@@ -218,7 +218,15 @@ class DuoUniversal_WordpressPlugin {
 			\remove_action( 'authenticate', 'wp_authenticate_username_password', 20 );
 			\remove_action( 'authenticate', 'wp_authenticate_email_password', 20 );
 
-			$user = \wp_authenticate_username_password( null, $username, $password );
+			/**
+			 * Filter the user object, allowing other plugins to provide their own authentication methods.
+			 *
+			 * @param WP_User|WP_Error $user The authenticated user object or WP_Error on failure.
+			 * @param string           $username The username passed to the primary authentication method.
+			 * @param string           $password The password passed to the primary authentication method.
+			 *
+			 */
+			$user = \apply_filters( 'duo_universal_authenticated_user', \wp_authenticate_username_password( null, $username, $password ), $username, $password );
 			if ( ! is_a( $user, 'WP_User' ) ) {
 				// maybe we got an email?
 				$user = \wp_authenticate_email_password( null, $username, $password );


### PR DESCRIPTION
## Description
Added a filter to the user object to allow other plugins to provide their own authentication methods. This change introduces a new filter `duo_universal_authenticated_user` which can be used to modify the authenticated user object or handle authentication in a custom way.

## Motivation and Context
This change is required to provide flexibility in the authentication process, allowing other plugins to hook into the authentication flow and provide their own methods. It solves the problem of rigid authentication by enabling extensibility through WordPress filters.

## How Has This Been Tested?
- Verified that the filter `duo_universal_authenticated_user` is applied correctly during the authentication process.
- Tested with a custom plugin to ensure it can modify the user object as expected.
- Ensured that the default authentication process remains unaffected when no custom plugins are hooked into the filter.

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)