### PR TITLE
Upgrade to require duo_universal_php 1.1.0

### DIFF
--- a/.github/workflows/wp_ci.yml
+++ b/.github/workflows/wp_ci.yml
@@ -40,7 +40,7 @@ jobs:
         run: ./vendor/bin/phpunit --process-isolation tests
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: duo-universal
           path: ./duo-universal.zip

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   ],
   "require": {
     "composer/installers": "~1.0",
-    "duosecurity/duo_universal_php": ">=1.0.1"
+    "duosecurity/duo_universal_php": ">=1.1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "991a25ed1815de443edb0e8637c74468",
+    "content-hash": "afd3b1b2ba55a2436c4eb78e8fc3681c",
     "packages": [
         {
             "name": "composer/installers",
@@ -159,25 +159,26 @@
         },
         {
             "name": "duosecurity/duo_universal_php",
-            "version": "1.0.1",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/duosecurity/duo_universal_php.git",
-                "reference": "d7d9bd3bf996d16ff7f4af57b45ed5ca3144cd16"
+                "reference": "a2852c46949a2de9ca6da908e4353a81c61b43a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/duosecurity/duo_universal_php/zipball/d7d9bd3bf996d16ff7f4af57b45ed5ca3144cd16",
-                "reference": "d7d9bd3bf996d16ff7f4af57b45ed5ca3144cd16",
+                "url": "https://api.github.com/repos/duosecurity/duo_universal_php/zipball/a2852c46949a2de9ca6da908e4353a81c61b43a3",
+                "reference": "a2852c46949a2de9ca6da908e4353a81c61b43a3",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
+                "ext-json": "*",
                 "firebase/php-jwt": "^6.0",
-                "php": ">=7.3"
+                "php": ">=7.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.0",
+                "phpunit/phpunit": "^9.0",
                 "squizlabs/php_codesniffer": "3.*"
             },
             "type": "library",
@@ -187,14 +188,17 @@
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
             "description": "A PHP implementation of the Duo Universal SDK.",
             "homepage": "https://duo.com/",
             "support": {
                 "email": "support@duosecurity.com",
                 "issues": "https://github.com/duosecurity/duo_universal_php/issues",
-                "source": "https://github.com/duosecurity/duo_universal_php/tree/1.0.1"
+                "source": "https://github.com/duosecurity/duo_universal_php/tree/1.1.0"
             },
-            "time": "2022-07-06T13:56:13+00:00"
+            "time": "2025-03-05T18:33:28+00:00"
         },
         {
             "name": "firebase/php-jwt",
@@ -2570,10 +2574,10 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
## Description
Update composer.json file so wordpress plugin uses the latest version of our universal php repo.

## Motivation and Context
Required for CA pinning since Wordpress plugin relies on PHP plugin.

## How Has This Been Tested?
Testing manually

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
