### PR TITLE
Send a wordpress-specific user agent

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   ],
   "require": {
     "composer/installers": "~1.0",
-    "duosecurity/duo_universal_php": ">=1.1.0"
+    "duosecurity/duo_universal_php": ">=1.1.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "afd3b1b2ba55a2436c4eb78e8fc3681c",
+    "content-hash": "9907b2b1b901e0eaf89dc3174a348227",
     "packages": [
         {
             "name": "composer/installers",
@@ -159,16 +159,16 @@
         },
         {
             "name": "duosecurity/duo_universal_php",
-            "version": "1.1.0",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/duosecurity/duo_universal_php.git",
-                "reference": "a2852c46949a2de9ca6da908e4353a81c61b43a3"
+                "reference": "4ee7253863d84653a60a8cad4b03aa3b66fcfd35"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/duosecurity/duo_universal_php/zipball/a2852c46949a2de9ca6da908e4353a81c61b43a3",
-                "reference": "a2852c46949a2de9ca6da908e4353a81c61b43a3",
+                "url": "https://api.github.com/repos/duosecurity/duo_universal_php/zipball/4ee7253863d84653a60a8cad4b03aa3b66fcfd35",
+                "reference": "4ee7253863d84653a60a8cad4b03aa3b66fcfd35",
                 "shasum": ""
             },
             "require": {
@@ -196,9 +196,9 @@
             "support": {
                 "email": "support@duosecurity.com",
                 "issues": "https://github.com/duosecurity/duo_universal_php/issues",
-                "source": "https://github.com/duosecurity/duo_universal_php/tree/1.1.0"
+                "source": "https://github.com/duosecurity/duo_universal_php/tree/1.1.1"
             },
-            "time": "2025-03-05T18:33:28+00:00"
+            "time": "2025-08-13T14:05:56+00:00"
         },
         {
             "name": "firebase/php-jwt",

--- a/duouniversal-wordpress.php
+++ b/duouniversal-wordpress.php
@@ -61,6 +61,35 @@ $settings = new Duo\DuoUniversalWordpress\DuoUniversal_Settings(
 	$utils
 );
 
+/**
+ * Extend User Agent string with WordPress-specific information
+ */
+function duo_extend_user_agent() {
+	global $duo_client, $utils;
+
+	if ( $duo_client && $utils && $utils->duo_auth_enabled() ) {
+		try {
+			if ( ! function_exists( 'get_plugin_data' ) ) {
+				require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+			}
+			$plugin_data = get_plugin_data( __FILE__ );
+			$plugin_version = $plugin_data['Version'];
+
+			global $wp_version;
+
+			$user_agent_extension = sprintf(
+				'duo_universal_wordpress/%s (wordpress_version=%s)',
+				$plugin_version,
+				$wp_version
+			);
+
+			$duo_client->appendToUserAgent( $user_agent_extension );
+		} catch ( Exception $e ) {
+			$utils->duo_debug_log( $e->getMessage() );
+		}
+	}
+}
+
 if ( ! \is_multisite() ) {
 	$plugin_name = plugin_basename( __FILE__ );
 	add_filter( 'plugin_action_links_' . $plugin_name, array( $settings, 'duo_add_link' ), 10, 2 );
@@ -74,6 +103,8 @@ if ( $duoup_plugin->duo_utils->duo_get_option( 'duoup_xmlrpc', 'off' ) === 'off'
 }
 
 /*-------------Register WordPress Hooks-------------*/
+
+\add_action( 'init', 'duo_extend_user_agent' );
 
 \add_action( 'init', array( $duoup_plugin, 'duo_verify_auth' ), 10 );
 


### PR DESCRIPTION
## Description
Added User Agent extension functionality to include WordPress-specific information in API requests to Duo's servers. The implementation extends the base Duo client User Agent string with plugin version and WordPress version details.

## Motivation and Context
This change enables better tracking and debugging of API requests from WordPress installations in Duo's logs. 

## How Has This Been Tested?
Manual Testing
## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
