### PR TITLE
Support for sending email as user identifier

### DIFF
--- a/class-duouniversal-settings.php
+++ b/class-duouniversal-settings.php
@@ -138,6 +138,35 @@ class DuoUniversal_Settings {
 		return $failmode;
 	}
 
+	public function duo_settings_username_attribute() {
+		$attribute = \esc_attr( $this->duo_utils->duo_get_option( 'duoup_username_attribute', 'username' ) );
+		$result    = '';
+		$result   .= '<select id="duoup_username_attribute" name="duoup_username_attribute">';
+		$result   .= sprintf(
+			'<option value="username" %s>%s</option>',
+			'username' === $attribute ? 'selected' : '',
+			\esc_html__( 'Username', 'duo-universal' )
+		);
+		$result   .= sprintf(
+			'<option value="email" %s>%s</option>',
+			'email' === $attribute ? 'selected' : '',
+			\esc_html__( 'Email Address', 'duo-universal' )
+		);
+		$result   .= '</select>';
+		$result   .= '<p class="description">' . \esc_html__( 'Choose which WordPress user attribute is sent to Duo as the username. This must match how users are enrolled in Duo.', 'duo-universal' ) . '</p>';
+		return $result;
+	}
+
+	public function duoup_username_attribute_validate( $attribute ) {
+		$attribute = sanitize_text_field( $attribute );
+		if ( ! in_array( $attribute, array( 'username', 'email' ), true ) ) {
+			\add_settings_error( 'duoup_username_attribute', '', __( 'Username attribute value is not valid', 'duo-universal' ) );
+			$current_attribute = $this->duo_utils->duo_get_option( 'duoup_username_attribute', 'username' );
+			return $current_attribute;
+		}
+		return $attribute;
+	}
+
 	public function duo_settings_roles() {
 		$wp_roles = $this->duo_utils->duo_get_roles();
 		$roles    = $wp_roles->get_names();
@@ -285,6 +314,9 @@ class DuoUniversal_Settings {
 						'selected' => array(),
 					),
 					'br'     => array(),
+					'p'      => array(
+						'class' => array(),
+					),
 				),
 			)
 		);
@@ -303,6 +335,7 @@ class DuoUniversal_Settings {
 			$this->duo_add_site_option( 'duoup_client_secret', '' );
 			$this->duo_add_site_option( 'duoup_api_host', '' );
 			$this->duo_add_site_option( 'duoup_failmode', '' );
+			$this->duo_add_site_option( 'duoup_username_attribute', 'username' );
 			$this->duo_add_site_option( 'duoup_roles', $allroles );
 			$this->duo_add_site_option( 'duoup_xmlrpc', 'off' );
 		} else {
@@ -311,6 +344,7 @@ class DuoUniversal_Settings {
 			$this->duoup_add_settings_field( 'duoup_client_secret', __( 'Client Secret', 'duo-universal' ), array( $this, 'printing_callback' ), array( $this, 'duoup_client_secret_validate' ), $this->duo_settings_client_secret() );
 			$this->duoup_add_settings_field( 'duoup_api_host', __( 'API hostname', 'duo-universal' ), array( $this, 'printing_callback' ), array( $this, 'duoup_api_host_validate' ), $this->duo_settings_host() );
 			$this->duoup_add_settings_field( 'duoup_failmode', __( 'Failmode', 'duo-universal' ), array( $this, 'printing_callback' ), array( $this, 'duoup_failmode_validate' ), $this->duo_settings_failmode() );
+			$this->duoup_add_settings_field( 'duoup_username_attribute', __( 'Duo Username', 'duo-universal' ), array( $this, 'printing_callback' ), array( $this, 'duoup_username_attribute_validate' ), $this->duo_settings_username_attribute() );
 			$this->duoup_add_settings_field( 'duoup_roles', __( 'Enable for roles:', 'duo-universal' ), array( $this, 'printing_callback' ), array( $this, 'duoup_roles_validate' ), $this->duo_settings_roles() );
 			$this->duoup_add_settings_field( 'duoup_xmlrpc', __( 'Disable XML-RPC (recommended)', 'duo-universal' ), array( $this, 'printing_callback' ), array( $this, 'duoup_xmlrpc_validate' ), $this->duo_settings_xmlrpc() );
 		}
@@ -342,6 +376,9 @@ class DuoUniversal_Settings {
 						'selected' => array(),
 					),
 					'br'     => array(),
+					'p'      => array(
+						'class' => array(),
+					),
 				),
 			)
 		);
@@ -358,6 +395,7 @@ class DuoUniversal_Settings {
 			$this->print_field( 'duoup_client_secret', \__( 'Client Secret', 'duo-universal' ), $this->duo_settings_client_secret() );
 			$this->print_field( 'duoup_api_host', \__( 'API hostname', 'duo-universal' ), $this->duo_settings_host() );
 			$this->print_field( 'duoup_failmode', \__( 'Failmode', 'duo-universal' ), $this->duo_settings_failmode() );
+			$this->print_field( 'duoup_username_attribute', \__( 'Duo Username', 'duo-universal' ), $this->duo_settings_username_attribute() );
 			$this->print_field( 'duoup_roles', \__( 'Roles', 'duo-universal' ), $this->duo_settings_roles() );
 			$this->print_field( 'duoup_xmlrpc', \__( 'Disable XML-RPC (recommended)', 'duo-universal' ), $this->duo_settings_xmlrpc() );
 		echo( "</table>\n" );
@@ -386,6 +424,13 @@ class DuoUniversal_Settings {
 			$result   = \update_site_option( 'duoup_failmode', $failmode );
 		} else {
 			$result = \update_site_option( 'duoup_failmode', 'open' );
+		}
+
+		if ( isset( $_POST['duoup_username_attribute'] ) ) {
+			$attribute = $this->duoup_username_attribute_validate( sanitize_text_field( \wp_unslash( $_POST['duoup_username_attribute'] ) ) );
+			$result    = \update_site_option( 'duoup_username_attribute', $attribute );
+		} else {
+			$result = \update_site_option( 'duoup_username_attribute', 'username' );
 		}
 
 		if ( isset( $_POST['duoup_roles'] ) ) {

--- a/class-duouniversal-wordpressplugin.php
+++ b/class-duouniversal-wordpressplugin.php
@@ -34,6 +34,22 @@ class DuoUniversal_WordpressPlugin {
 		$this->duo_client = $duo_client;
 		$this->duo_utils  = $duo_utils;
 	}
+
+	/**
+	 * Returns the identifier to send to Duo for a given user,
+	 * based on the duoup_username_attribute setting.
+	 *
+	 * @param \WP_User $user The WordPress user object.
+	 * @return string The username or email to pass to Duo.
+	 */
+	function get_duo_username( $user ) {
+		$attribute = $this->duo_utils->duo_get_option( 'duoup_username_attribute', 'username' );
+		if ( 'email' === $attribute ) {
+			return $user->user_email;
+		}
+		return $user->user_login;
+	}
+
 	/**
 	 * Sets a user's auth state
 	 * user: username of the user to update
@@ -132,7 +148,9 @@ class DuoUniversal_WordpressPlugin {
 
 		$this->update_user_auth_status( $user->ID, 'in-progress', $redirect_url, $oidc_state );
 
-		$prompt_uri = $this->duo_client->createAuthUrl( $user->user_login, $oidc_state );
+		$duo_username = $this->get_duo_username( $user );
+		$this->duo_debug_log( "Starting Duo auth for user identifier: $duo_username" );
+		$prompt_uri = $this->duo_client->createAuthUrl( $duo_username, $oidc_state );
 		\wp_redirect( $prompt_uri );
 		$this->exit();
 	}
@@ -196,7 +214,8 @@ class DuoUniversal_WordpressPlugin {
 			try {
 				// Update redirect URL to be one associated with initial authentication.
 				$this->duo_client->redirect_url = $this->get_redirect_url( $associated_user->ID );
-				$decoded_token                  = $this->duo_client->exchangeAuthorizationCodeFor2FAResult( $code, $associated_user->user_login );
+				$duo_username                   = $this->get_duo_username( $associated_user );
+				$decoded_token                  = $this->duo_client->exchangeAuthorizationCodeFor2FAResult( $code, $duo_username );
 			} catch ( \Duo\DuoUniversal\DuoException $e ) {
 				$this->duo_debug_log( $e->getMessage() );
 				$error = $this->duo_utils->new_WP_Error(

--- a/tests/duoUniversalAuthenticationTest.php
+++ b/tests/duoUniversalAuthenticationTest.php
@@ -70,6 +70,7 @@ final class authenticationTest extends WPTestCase
         ->setMockClassName('WP_User')
         ->getMock();
         $user->user_login = "test user";
+        $user->user_email = "testuser@example.com";
         $user->ID = 1;
         return $user;
     }
@@ -84,6 +85,132 @@ final class authenticationTest extends WPTestCase
         WP_Mock::passthruFunction('sanitize_text_field');
 
         $this->duo_utils = $this->createMock(Duo\DuoUniversalWordpress\DuoUniversal_Utilities::class);
+    }
+
+    /**
+     * Test that get_duo_username returns user_login by default
+     */
+    function testGetDuoUsernameDefaultIsLogin(): void
+    {
+        $duo_utils = $this->getMockBuilder(Duo\DuoUniversalWordpress\DuoUniversal_Utilities::class)
+            ->onlyMethods(['duo_get_option'])
+            ->getMock();
+        $duo_utils->method('duo_get_option')->with('duoup_username_attribute', 'username')->willReturn('username');
+        $authentication = new Duo\DuoUniversalWordpress\DuoUniversal_WordPressPlugin($duo_utils, $this->duo_client);
+        $user = $this->createMockUser();
+
+        $result = $authentication->get_duo_username($user);
+
+        $this->assertEquals("test user", $result);
+    }
+
+    /**
+     * Test that get_duo_username returns user_email when setting is 'email'
+     */
+    function testGetDuoUsernameReturnsEmailWhenConfigured(): void
+    {
+        $duo_utils = $this->getMockBuilder(Duo\DuoUniversalWordpress\DuoUniversal_Utilities::class)
+            ->onlyMethods(['duo_get_option'])
+            ->getMock();
+        $duo_utils->method('duo_get_option')->with('duoup_username_attribute', 'username')->willReturn('email');
+        $authentication = new Duo\DuoUniversalWordpress\DuoUniversal_WordPressPlugin($duo_utils, $this->duo_client);
+        $user = $this->createMockUser();
+
+        $result = $authentication->get_duo_username($user);
+
+        $this->assertEquals("testuser@example.com", $result);
+    }
+
+    /**
+     * Test that createAuthUrl receives the email when username attribute is 'email'
+     */
+    function testStartSecondFactorPassesEmailToDuo(): void
+    {
+        $this->setUpMocks();
+        $user = $this->createMockUser();
+        $duo_utils = $this->getMockBuilder(Duo\DuoUniversalWordpress\DuoUniversal_Utilities::class)
+            ->onlyMethods(['duo_get_option', 'duo_debug_log'])
+            ->getMock();
+        $duo_utils->method('duo_get_option')->willReturn('email');
+        $this->duo_client->expects($this->once())
+            ->method('createAuthUrl')
+            ->with($this->equalTo('testuser@example.com'), $this->anything())
+            ->willReturn('prompt url');
+
+        $authentication = $this->getMockBuilder(Duo\DuoUniversalWordpress\DuoUniversal_WordPressPlugin::class)
+            ->setConstructorArgs(array($duo_utils, $this->duo_client))
+            ->onlyMethods(['get_page_url', 'exit'])
+            ->getMock();
+        $authentication->method('get_page_url')->willReturn('fake url');
+        WP_Mock::passthruFunction('wp_redirect');
+
+        $authentication->duo_start_second_factor($user);
+        $this->assertConditionsMet();
+    }
+
+    /**
+     * Test that createAuthUrl receives user_login when username attribute is 'username'
+     */
+    function testStartSecondFactorPassesUsernameToDuo(): void
+    {
+        $this->setUpMocks();
+        $user = $this->createMockUser();
+        $duo_utils = $this->getMockBuilder(Duo\DuoUniversalWordpress\DuoUniversal_Utilities::class)
+            ->onlyMethods(['duo_get_option', 'duo_debug_log'])
+            ->getMock();
+        $duo_utils->method('duo_get_option')->willReturn('username');
+        $this->duo_client->expects($this->once())
+            ->method('createAuthUrl')
+            ->with($this->equalTo('test user'), $this->anything())
+            ->willReturn('prompt url');
+
+        $authentication = $this->getMockBuilder(Duo\DuoUniversalWordpress\DuoUniversal_WordPressPlugin::class)
+            ->setConstructorArgs(array($duo_utils, $this->duo_client))
+            ->onlyMethods(['get_page_url', 'exit'])
+            ->getMock();
+        $authentication->method('get_page_url')->willReturn('fake url');
+        WP_Mock::passthruFunction('wp_redirect');
+
+        $authentication->duo_start_second_factor($user);
+        $this->assertConditionsMet();
+    }
+
+    /**
+     * Test that exchangeAuthorizationCodeFor2FAResult receives the email
+     * when username attribute is 'email' during secondary auth
+     */
+    function testSecondaryAuthPassesEmailToDuo(): void
+    {
+        $this->setUpMocks();
+        WP_Mock::passthruFunction('wp_unslash');
+        $user = $this->createMockUser();
+        $duo_utils = $this->getMockBuilder(Duo\DuoUniversalWordpress\DuoUniversal_Utilities::class)
+            ->onlyMethods(['duo_get_option', 'duo_debug_log', 'duo_auth_enabled', 'new_WP_user'])
+            ->getMock();
+        $duo_utils->method('duo_auth_enabled')->willReturn(true);
+        $duo_utils->method('duo_get_option')->willReturn('email');
+        $duo_utils->method('new_WP_user')->willReturnArgument(1);
+
+        $this->duo_client->expects($this->once())
+            ->method('exchangeAuthorizationCodeFor2FAResult')
+            ->with($this->equalTo('testcode'), $this->equalTo('testuser@example.com'));
+
+        $authentication = $this->getMockBuilder(Duo\DuoUniversalWordpress\DuoUniversal_WordPressPlugin::class)
+            ->setConstructorArgs(array($duo_utils, $this->duo_client))
+            ->onlyMethods(
+                [
+                'get_user_from_oidc_state',
+                'get_redirect_url'
+                ]
+            )
+            ->getMock();
+        $authentication->method('get_user_from_oidc_state')->willReturn($user);
+
+        $_GET['duo_code'] = "testcode";
+        $_GET['state'] = "teststate";
+
+        $authentication->duo_authenticate_user();
+        $this->assertConditionsMet();
     }
 
     /**

--- a/tests/duoUniversalSettingsTest.php
+++ b/tests/duoUniversalSettingsTest.php
@@ -275,6 +275,79 @@ final class SettingsTest extends WPTestCase
     }
 
     /**
+     * Test that the username attribute dropdown shows up in output
+     * with 'username' selected by default
+     */
+    public function testSettingsUsernameAttributeDefaultUsername(): void
+    {
+        WP_Mock::passthruFunction('esc_attr');
+        WP_Mock::passthruFunction('esc_html__');
+        $duo_utils = $this->getMockBuilder(Duo\DuoUniversalWordpress\DuoUniversal_Utilities::class)
+            ->onlyMethods(['duo_get_option'])
+            ->getMock();
+        $duo_utils->method('duo_get_option')->willReturn("username");
+        $settings = new Duo\DuoUniversalWordpress\DuoUniversal_Settings($duo_utils);
+
+        $output = $settings->duo_settings_username_attribute();
+        $this->assertEquals( 1, preg_match('/"username" selected/', $output));
+        $this->assertEquals( 0, preg_match('/"email" selected/', $output));
+    }
+
+    /**
+     * Test that the username attribute dropdown shows up in output
+     * with 'email' selected when configured
+     */
+    public function testSettingsUsernameAttributeEmail(): void
+    {
+        WP_Mock::passthruFunction('esc_attr');
+        WP_Mock::passthruFunction('esc_html__');
+        $duo_utils = $this->getMockBuilder(Duo\DuoUniversalWordpress\DuoUniversal_Utilities::class)
+            ->onlyMethods(['duo_get_option'])
+            ->getMock();
+        $duo_utils->method('duo_get_option')->willReturn("email");
+        $settings = new Duo\DuoUniversalWordpress\DuoUniversal_Settings($duo_utils);
+
+        $output = $settings->duo_settings_username_attribute();
+        $this->assertEquals( 1, preg_match('/"email" selected/', $output));
+        $this->assertEquals( 0, preg_match('/"username" selected/', $output));
+    }
+
+    /**
+     * Test that a valid username attribute value validates
+     */
+    public function testDuoUsernameAttributeValidateValidUsername(): void
+    {
+        $settings = new Duo\DuoUniversalWordpress\DuoUniversal_Settings($this->duo_utils);
+        $result = $settings->duoup_username_attribute_validate('username');
+        $this->assertEquals('username', $result);
+    }
+
+    /**
+     * Test that a valid email attribute value validates
+     */
+    public function testDuoUsernameAttributeValidateValidEmail(): void
+    {
+        $settings = new Duo\DuoUniversalWordpress\DuoUniversal_Settings($this->duo_utils);
+        $result = $settings->duoup_username_attribute_validate('email');
+        $this->assertEquals('email', $result);
+    }
+
+    /**
+     * Test that an invalid username attribute value is rejected
+     * and the current value is preserved
+     */
+    public function testDuoUsernameAttributeValidateInvalid(): void
+    {
+        $this->duo_utils->method('duo_get_option')->willReturn('email');
+        WP_Mock::userFunction('add_settings_error')->once()->with('duoup_username_attribute', '', 'Username attribute value is not valid')->andReturn(null);
+
+        $settings = new Duo\DuoUniversalWordpress\DuoUniversal_Settings($this->duo_utils);
+        $result = $settings->duoup_username_attribute_validate('foobar');
+
+        $this->assertEquals('email', $result);
+    }
+
+    /**
      * Test that selected roles show up as checked
      * when generating role HTML
      */
@@ -505,6 +578,7 @@ final class SettingsTest extends WPTestCase
         $this->expectOutputRegex("/<label for='duoup_client_secret'>Client Secret<\/label>/");
         $this->expectOutputRegex("/<label for='duoup_api_host'>API hostname<\/label>/");
         $this->expectOutputRegex("/<label for='duoup_failmode'>Failmode<\/label>/");
+        $this->expectOutputRegex("/<label for='duoup_username_attribute'>Duo Username<\/label>/");
         $this->expectOutputRegex("/<label for='duoup_roles'>Roles<\/label>/");
         $this->expectOutputRegex("/<label for='duoup_xmlrpc'>Disable XML-RPC \(recommended\)<\/label>/");
 
@@ -535,13 +609,14 @@ final class SettingsTest extends WPTestCase
             ->onlyMethods(['duo_add_site_option'])
             ->getMock();
 
-        $settings->expects($this->exactly(6))
+        $settings->expects($this->exactly(7))
             ->method('duo_add_site_option')
             ->withConsecutive(
                 ['duoup_client_id', ''],
                 ['duoup_client_secret', ''],
                 ['duoup_api_host', ''],
                 ['duoup_failmode', ''],
+                ['duoup_username_attribute', 'username'],
                 ['duoup_roles', $duoup_roles],
                 ['duoup_xmlrpc', 'off'],
             );
@@ -558,7 +633,7 @@ final class SettingsTest extends WPTestCase
         WP_Mock::userFunction('is_multisite', ['return' => false]);
         $settings = $this->getMockBuilder(Duo\DuoUniversalWordpress\DuoUniversal_Settings::class)
             ->setConstructorArgs(array($this->duo_utils))
-            ->onlyMethods(['duo_settings_client_id', 'duo_settings_client_secret', 'duo_settings_host', 'duo_settings_failmode', 'duo_settings_roles', 'duo_settings_xmlrpc'])
+            ->onlyMethods(['duo_settings_client_id', 'duo_settings_client_secret', 'duo_settings_host', 'duo_settings_failmode', 'duo_settings_username_attribute', 'duo_settings_roles', 'duo_settings_xmlrpc'])
             ->getMock();
 
         WP_Mock::userFunction('add_settings_section')->once()->with('duo_universal_settings', 'Main Settings', array($settings, 'duo_settings_text'), 'duo_universal_settings');
@@ -567,6 +642,7 @@ final class SettingsTest extends WPTestCase
         WP_Mock::userFunction('add_settings_field')->once()->with('duoup_client_secret', 'Client Secret', array($settings, 'printing_callback'), 'duo_universal_settings', 'duo_universal_settings', array('text' => $settings->duo_settings_client_secret(), 'label_for' => 'duoup_client_secret'));
         WP_Mock::userFunction('add_settings_field')->once()->with('duoup_api_host', 'API hostname', array($settings, 'printing_callback'), 'duo_universal_settings', 'duo_universal_settings', array('text' => $settings->duo_settings_host(), 'label_for' => 'duoup_api_host'));
         WP_Mock::userFunction('add_settings_field')->once()->with('duoup_failmode', 'Failmode', array($settings, 'printing_callback'), 'duo_universal_settings', 'duo_universal_settings', array('text' => $settings->duo_settings_failmode(), 'label_for' => 'duoup_failmode'));
+        WP_Mock::userFunction('add_settings_field')->once()->with('duoup_username_attribute', 'Duo Username', array($settings, 'printing_callback'), 'duo_universal_settings', 'duo_universal_settings', array('text' => $settings->duo_settings_username_attribute(), 'label_for' => 'duoup_username_attribute'));
         WP_Mock::userFunction('add_settings_field')->once()->with('duoup_roles', 'Enable for roles:', array($settings, 'printing_callback'), 'duo_universal_settings', 'duo_universal_settings', array('text' => $settings->duo_settings_roles(), 'label_for' => 'duoup_roles'));
         WP_Mock::userFunction('add_settings_field')->once()->with('duoup_xmlrpc', 'Disable XML-RPC (recommended)', array($settings, 'printing_callback'), 'duo_universal_settings', 'duo_universal_settings', array('text' => $settings->duo_settings_xmlrpc(), 'label_for' => 'duoup_xmlrpc'));
 
@@ -574,6 +650,7 @@ final class SettingsTest extends WPTestCase
         WP_Mock::userFunction('register_setting')->once()->with('duo_universal_settings', 'duoup_client_secret', array($settings, 'duoup_client_secret_validate'));
         WP_Mock::userFunction('register_setting')->once()->with('duo_universal_settings', 'duoup_api_host', array($settings, 'duoup_api_host_validate'));
         WP_Mock::userFunction('register_setting')->once()->with('duo_universal_settings', 'duoup_failmode', array($settings, 'duoup_failmode_validate'));
+        WP_Mock::userFunction('register_setting')->once()->with('duo_universal_settings', 'duoup_username_attribute', array($settings, 'duoup_username_attribute_validate'));
         WP_Mock::userFunction('register_setting')->once()->with('duo_universal_settings', 'duoup_roles', array($settings, 'duoup_roles_validate'));
         WP_Mock::userFunction('register_setting')->once()->with('duo_universal_settings', 'duoup_xmlrpc', array($settings, 'duoup_xmlrpc_validate'));
 
@@ -602,6 +679,7 @@ final class SettingsTest extends WPTestCase
             'duoup_client_secret' => str_repeat('aBc123As3cr3t4uandme', 2),
             'duoup_api_host' => 'api-duo1.duo.test',
             'duoup_failmode' => 'closed',
+            'duoup_username_attribute' => 'email',
             'duoup_roles' => $duoup_roles,
             'duoup_xmlrpc' => 'off'
         );
@@ -610,6 +688,7 @@ final class SettingsTest extends WPTestCase
         WP_Mock::userFunction('update_site_option')->once()->with('duoup_client_secret', str_repeat('aBc123As3cr3t4uandme', 2));
         WP_Mock::userFunction('update_site_option')->once()->with('duoup_api_host', 'api-duo1.duo.test');
         WP_Mock::userFunction('update_site_option')->once()->with('duoup_failmode', 'closed');
+        WP_Mock::userFunction('update_site_option')->once()->with('duoup_username_attribute', 'email');
         WP_Mock::userFunction('update_site_option')->once()->with('duoup_roles', $duoup_roles);
         WP_Mock::userFunction('update_site_option')->once()->with('duoup_xmlrpc', 'off');
         WP_Mock::passthruFunction('check_admin_referer');
@@ -627,6 +706,7 @@ final class SettingsTest extends WPTestCase
     public function testDuoMultisiteUpdateWithEmptyPostValue(): void
     {
         WP_Mock::userFunction('update_site_option')->once()->with('duoup_failmode', 'open');
+        WP_Mock::userFunction('update_site_option')->once()->with('duoup_username_attribute', 'username');
         WP_Mock::userFunction('update_site_option')->once()->with('duoup_roles', []);
         WP_Mock::userFunction('update_site_option')->once()->with('duoup_xmlrpc', 'on');
         WP_Mock::passthruFunction('check_admin_referer');

--- a/uninstall.php
+++ b/uninstall.php
@@ -27,6 +27,7 @@ delete_option( 'duoup_client_secret' );
 delete_option( 'duoup_api_host' );
 delete_option( 'duoup_roles' );
 delete_option( 'duoup_failmode' );
+delete_option( 'duoup_username_attribute' );
 delete_option( 'duoup_xmlrpc' );
 
 // Delete Duo credentials in wp_sitemeta
@@ -35,6 +36,7 @@ delete_site_option( 'duoup_client_secret' );
 delete_site_option( 'duoup_api_host' );
 delete_site_option( 'duoup_roles' );
 delete_site_option( 'duoup_failmode' );
+delete_site_option( 'duoup_username_attribute' );
 delete_site_option( 'duoup_xmlrpc' );
 
 // Delete Duo user_meta fields for all users


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
Allows you to configure what is sent to Duo to match users, adds the support for email address to be sent.
<img width="143" height="103" alt="2026-04-21_15-50-03" src="https://github.com/user-attachments/assets/350075eb-d643-4ea2-aaf5-b6a9ddb4a0a6" />
<img width="984" height="79" alt="2026-04-21_15-49-57" src="https://github.com/user-attachments/assets/1238e5a1-7eee-4666-b2b3-a4d524025d89" />

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We didnt use the same username format on our wordpress sites to the rest of our systems, so email address was needed to be sent instead to match Duo users correctly.

## How Has This Been Tested?
<!--- Please describe how you tested your changes, or what tests were added -->
Tested on our own test wordpress instance

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Please note Claude was used to assist this change