### PR TITLE
Skip CI for pull requests from unauthorized forks

### DIFF
--- a/.github/workflows/wp_ci.yml
+++ b/.github/workflows/wp_ci.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   ci:
+    # Fork PRs can modify package.sh, composer.json, etc.; skip CI for untrusted code.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
## Summary

- Skip the WordPress CI workflow for pull requests opened from forks
- CI still runs on pushes to `main`/`*.X` and on pull requests from branches in this repository

## Why

The workflow runs `./package.sh`, `composer install` (including post-install scripts), and PHPUnit against PR code. For fork PRs, that means untrusted code executes on GitHub-hosted runners (supply-chain finding from the GHA security scan).

## Change

Add a job-level guard:

```yaml
if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
```

## Tradeoff

External contributors who open PRs from forks will not get automatic CI results. Maintainers can still test by pushing a branch to this repo or running CI locally before merge.

## Test plan

- [ ] Push to a branch in `duosecurity/duo_universal_wordpress` and confirm CI runs
- [ ] Open a PR from a fork and confirm the workflow is skipped
