### PR TITLE
chore: update GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/wp_ci.yml
+++ b/.github/workflows/wp_ci.yml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@86e1ccdd8ddc47bffc29bf667143f363a4cdfdbc
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           php-version: ${{ matrix.php }}
           coverage: xdebug
@@ -45,7 +45,7 @@ jobs:
         run: echo "SHA256 " && sha256sum ./duo-universal.zip
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: duo-universal
           path: ./duo-universal.zip


### PR DESCRIPTION
## Summary
Updates GitHub Actions to Node 24-compatible versions ahead of the runner change: GitHub Actions runners default to Node 24 on **2026-06-16** and remove Node 20 in **fall 2026**. JS actions on Node 12/16/20 are all affected.

Every JS-based action is bumped to its latest Node 24-capable release, **SHA-pinned** with a version comment.

## Not changed (no Node 24 release / composite / archived)
- `darenm/Setup-VSTest` — no Node 24 release exists
- `dtolnay/rust-toolchain` — composite action, unaffected
- `actions/create-release`, `actions/upload-release-asset` — archived; need a rewrite

Only present where applicable in this repo.

Ref: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

*This PR was generated with AI assistance (Claude).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)