### PR TITLE
Harden CI workflow: least-privilege token and --no-scripts

### DIFF
--- a/.github/workflows/wp_ci.yml
+++ b/.github/workflows/wp_ci.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest
@@ -29,14 +32,14 @@ jobs:
           coverage: xdebug
 
       - name: Composer install prod dependencies
-        run: composer install --no-dev
+        run: composer install --no-dev --no-scripts
 
         # Package before installing dev dependencies so we don't include them in the production zip
       - name: Package duo-universal
         run: ./package.sh
 
       - name: Composer install dev dependencies
-        run: composer install
+        run: composer install --no-scripts
 
       - name: PHP tests
         run: ./vendor/bin/phpunit --process-isolation tests


### PR DESCRIPTION
## Summary

Two defense-in-depth hardening changes to `wp_ci.yml`. Both target the fact that the workflow builds untrusted fork PR code on the runner.

1. **Explicit least-privilege token** — added a top-level `permissions: contents: read` block so `GITHUB_TOKEN` is read-only regardless of repo/org defaults.
2. **`--no-scripts` on both composer installs** — blocks package post-install scripts (e.g. a malicious `composer.json` in a fork PR adding a `post-install-cmd`) from executing on the runner.

## Verification

Simulated the full CI job in a PHP 8.1 container (matching the CI matrix):

- `composer install --no-dev --no-scripts` → prod deps installed
- `./package.sh` → `duo-universal.zip` built
- `composer install --no-scripts` → dev deps installed; PHPCS still reports `WordPress`, `WordPress-Core`, `WordPress-Docs`, `WordPress-Extra` standards registered
- **PHPUnit: 70 tests, 96 assertions, 0 failures** (2 pre-existing unrelated deprecation warnings)

*This PR description was generated with AI assistance (Claude).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)