### PR TITLE
Add admin setting to disable CA pinning, Add startup logging for CA bundle version and pinning status

### DIFF
--- a/class-duouniversal-settings.php
+++ b/class-duouniversal-settings.php
@@ -219,6 +219,24 @@ class DuoUniversal_Settings {
 		return 'on';
 	}
 
+	public function duo_settings_disable_ca_pinning() {
+		$val = '';
+		if ( $this->duo_utils->duo_get_option( 'duoup_disable_ca_pinning', 'off' ) === 'on' ) {
+			$val = 'checked=true';
+		}
+		$result  = sprintf( "<input id='duoup_disable_ca_pinning' name='duoup_disable_ca_pinning' type='checkbox' value='on' %s /> %s<br />", \esc_attr( $val ), \esc_html__( 'Yes', 'duo-universal' ) );
+		$result .= \esc_html__( 'Disabling CA pinning allows connections to validate via the OS trust store instead of pinned Duo certificates. Only disable this if required by your network environment (e.g., TLS-inspecting proxy). TLS verification is still enforced.', 'duo-universal' );
+		return $result;
+	}
+
+	public function duoup_disable_ca_pinning_validate( $option ) {
+		$option = sanitize_text_field( $option );
+		if ( 'on' === $option ) {
+			return $option;
+		}
+		return 'off';
+	}
+
 	public function duo_add_link( $links ) {
 		$settings_link = sprintf( '<a href="options-general.php?page=duo_universal">%s</a>', \esc_html__( 'Settings', 'duo-universal' ) );
 		array_unshift( $links, $settings_link );
@@ -305,6 +323,7 @@ class DuoUniversal_Settings {
 			$this->duo_add_site_option( 'duoup_failmode', '' );
 			$this->duo_add_site_option( 'duoup_roles', $allroles );
 			$this->duo_add_site_option( 'duoup_xmlrpc', 'off' );
+			$this->duo_add_site_option( 'duoup_disable_ca_pinning', 'off' );
 		} else {
 			\add_settings_section( 'duo_universal_settings', __( 'Main Settings', 'duo-universal' ), array( $this, 'duo_settings_text' ), 'duo_universal_settings' );
 			$this->duoup_add_settings_field( 'duoup_client_id', __( 'Client ID', 'duo-universal' ), array( $this, 'printing_callback' ), array( $this, 'duoup_client_id_validate' ), $this->duo_settings_client_id() );
@@ -313,6 +332,7 @@ class DuoUniversal_Settings {
 			$this->duoup_add_settings_field( 'duoup_failmode', __( 'Failmode', 'duo-universal' ), array( $this, 'printing_callback' ), array( $this, 'duoup_failmode_validate' ), $this->duo_settings_failmode() );
 			$this->duoup_add_settings_field( 'duoup_roles', __( 'Enable for roles:', 'duo-universal' ), array( $this, 'printing_callback' ), array( $this, 'duoup_roles_validate' ), $this->duo_settings_roles() );
 			$this->duoup_add_settings_field( 'duoup_xmlrpc', __( 'Disable XML-RPC (recommended)', 'duo-universal' ), array( $this, 'printing_callback' ), array( $this, 'duoup_xmlrpc_validate' ), $this->duo_settings_xmlrpc() );
+			$this->duoup_add_settings_field( 'duoup_disable_ca_pinning', __( 'Disable CA Pinning', 'duo-universal' ), array( $this, 'printing_callback' ), array( $this, 'duoup_disable_ca_pinning_validate' ), $this->duo_settings_disable_ca_pinning() );
 		}
 	}
 
@@ -360,6 +380,7 @@ class DuoUniversal_Settings {
 			$this->print_field( 'duoup_failmode', \__( 'Failmode', 'duo-universal' ), $this->duo_settings_failmode() );
 			$this->print_field( 'duoup_roles', \__( 'Roles', 'duo-universal' ), $this->duo_settings_roles() );
 			$this->print_field( 'duoup_xmlrpc', \__( 'Disable XML-RPC (recommended)', 'duo-universal' ), $this->duo_settings_xmlrpc() );
+			$this->print_field( 'duoup_disable_ca_pinning', \__( 'Disable CA Pinning', 'duo-universal' ), $this->duo_settings_disable_ca_pinning() );
 		echo( "</table>\n" );
 	}
 
@@ -401,6 +422,13 @@ class DuoUniversal_Settings {
 			$result = \update_site_option( 'duoup_xmlrpc', $xmlrpc );
 		} else {
 			$result = \update_site_option( 'duoup_xmlrpc', 'on' );
+		}
+
+		if ( isset( $_POST['duoup_disable_ca_pinning'] ) ) {
+			$disable_ca_pinning = $this->duoup_disable_ca_pinning_validate( sanitize_text_field( \wp_unslash( $_POST['duoup_disable_ca_pinning'] ) ) );
+			$result             = \update_site_option( 'duoup_disable_ca_pinning', $disable_ca_pinning );
+		} else {
+			$result = \update_site_option( 'duoup_disable_ca_pinning', 'off' );
 		}
 	}
 }

--- a/duouniversal-wordpress.php
+++ b/duouniversal-wordpress.php
@@ -43,7 +43,14 @@ if ( $utils->duo_auth_enabled() ) {
 			$utils->duo_get_option( 'duoup_client_secret' ),
 			$utils->duo_get_option( 'duoup_api_host' ),
 			'',
+			true,
+			null,
+			$utils->duo_get_option( 'duoup_disable_ca_pinning', 'off' ) === 'on',
 		);
+		$utils->duo_debug_log( 'CA bundle version: ' . Client::CA_BUNDLE_VERSION );
+		if ( $utils->duo_get_option( 'duoup_disable_ca_pinning', 'off' ) === 'on' ) {
+			$utils->duo_debug_log( 'WARNING: CA pinning is disabled via configuration' );
+		}
 	} catch ( Exception $e ) {
 		$utils->duo_debug_log( $e->getMessage() );
 		$duo_client = null;

--- a/tests/duoUniversalSettingsTest.php
+++ b/tests/duoUniversalSettingsTest.php
@@ -535,7 +535,7 @@ final class SettingsTest extends WPTestCase
             ->onlyMethods(['duo_add_site_option'])
             ->getMock();
 
-        $settings->expects($this->exactly(6))
+        $settings->expects($this->exactly(7))
             ->method('duo_add_site_option')
             ->withConsecutive(
                 ['duoup_client_id', ''],
@@ -544,6 +544,7 @@ final class SettingsTest extends WPTestCase
                 ['duoup_failmode', ''],
                 ['duoup_roles', $duoup_roles],
                 ['duoup_xmlrpc', 'off'],
+                ['duoup_disable_ca_pinning', 'off'],
             );
 
         $settings->duo_admin_init();
@@ -558,7 +559,7 @@ final class SettingsTest extends WPTestCase
         WP_Mock::userFunction('is_multisite', ['return' => false]);
         $settings = $this->getMockBuilder(Duo\DuoUniversalWordpress\DuoUniversal_Settings::class)
             ->setConstructorArgs(array($this->duo_utils))
-            ->onlyMethods(['duo_settings_client_id', 'duo_settings_client_secret', 'duo_settings_host', 'duo_settings_failmode', 'duo_settings_roles', 'duo_settings_xmlrpc'])
+            ->onlyMethods(['duo_settings_client_id', 'duo_settings_client_secret', 'duo_settings_host', 'duo_settings_failmode', 'duo_settings_roles', 'duo_settings_xmlrpc', 'duo_settings_disable_ca_pinning'])
             ->getMock();
 
         WP_Mock::userFunction('add_settings_section')->once()->with('duo_universal_settings', 'Main Settings', array($settings, 'duo_settings_text'), 'duo_universal_settings');
@@ -569,6 +570,7 @@ final class SettingsTest extends WPTestCase
         WP_Mock::userFunction('add_settings_field')->once()->with('duoup_failmode', 'Failmode', array($settings, 'printing_callback'), 'duo_universal_settings', 'duo_universal_settings', array('text' => $settings->duo_settings_failmode(), 'label_for' => 'duoup_failmode'));
         WP_Mock::userFunction('add_settings_field')->once()->with('duoup_roles', 'Enable for roles:', array($settings, 'printing_callback'), 'duo_universal_settings', 'duo_universal_settings', array('text' => $settings->duo_settings_roles(), 'label_for' => 'duoup_roles'));
         WP_Mock::userFunction('add_settings_field')->once()->with('duoup_xmlrpc', 'Disable XML-RPC (recommended)', array($settings, 'printing_callback'), 'duo_universal_settings', 'duo_universal_settings', array('text' => $settings->duo_settings_xmlrpc(), 'label_for' => 'duoup_xmlrpc'));
+        WP_Mock::userFunction('add_settings_field')->once()->with('duoup_disable_ca_pinning', 'Disable CA Pinning', array($settings, 'printing_callback'), 'duo_universal_settings', 'duo_universal_settings', array('text' => $settings->duo_settings_disable_ca_pinning(), 'label_for' => 'duoup_disable_ca_pinning'));
 
         WP_Mock::userFunction('register_setting')->once()->with('duo_universal_settings', 'duoup_client_id', array($settings, 'duoup_client_id_validate'));
         WP_Mock::userFunction('register_setting')->once()->with('duo_universal_settings', 'duoup_client_secret', array($settings, 'duoup_client_secret_validate'));
@@ -576,6 +578,7 @@ final class SettingsTest extends WPTestCase
         WP_Mock::userFunction('register_setting')->once()->with('duo_universal_settings', 'duoup_failmode', array($settings, 'duoup_failmode_validate'));
         WP_Mock::userFunction('register_setting')->once()->with('duo_universal_settings', 'duoup_roles', array($settings, 'duoup_roles_validate'));
         WP_Mock::userFunction('register_setting')->once()->with('duo_universal_settings', 'duoup_xmlrpc', array($settings, 'duoup_xmlrpc_validate'));
+        WP_Mock::userFunction('register_setting')->once()->with('duo_universal_settings', 'duoup_disable_ca_pinning', array($settings, 'duoup_disable_ca_pinning_validate'));
 
         $settings->duo_admin_init();
         $this->assertConditionsMet(); 
@@ -603,7 +606,8 @@ final class SettingsTest extends WPTestCase
             'duoup_api_host' => 'api-duo1.duo.test',
             'duoup_failmode' => 'closed',
             'duoup_roles' => $duoup_roles,
-            'duoup_xmlrpc' => 'off'
+            'duoup_xmlrpc' => 'off',
+            'duoup_disable_ca_pinning' => 'on'
         );
 
         WP_Mock::userFunction('update_site_option')->once()->with('duoup_client_id', 'DIAAAAAAAAAAAAAAAAAA');
@@ -612,6 +616,7 @@ final class SettingsTest extends WPTestCase
         WP_Mock::userFunction('update_site_option')->once()->with('duoup_failmode', 'closed');
         WP_Mock::userFunction('update_site_option')->once()->with('duoup_roles', $duoup_roles);
         WP_Mock::userFunction('update_site_option')->once()->with('duoup_xmlrpc', 'off');
+        WP_Mock::userFunction('update_site_option')->once()->with('duoup_disable_ca_pinning', 'on');
         WP_Mock::passthruFunction('check_admin_referer');
         WP_Mock::passthruFunction('wp_unslash');
 
@@ -629,11 +634,33 @@ final class SettingsTest extends WPTestCase
         WP_Mock::userFunction('update_site_option')->once()->with('duoup_failmode', 'open');
         WP_Mock::userFunction('update_site_option')->once()->with('duoup_roles', []);
         WP_Mock::userFunction('update_site_option')->once()->with('duoup_xmlrpc', 'on');
+        WP_Mock::userFunction('update_site_option')->once()->with('duoup_disable_ca_pinning', 'off');
         WP_Mock::passthruFunction('check_admin_referer');
 
         $settings = new Duo\DuoUniversalWordpress\DuoUniversal_Settings($this->duo_utils);
         $settings->duo_update_mu_options();
-        $this->assertConditionsMet(); 
+        $this->assertConditionsMet();
+    }
+
+    /**
+     * Test that disable CA pinning validate returns 'on' for valid input
+     */
+    public function testDuoDisableCaPinningValidateOn(): void
+    {
+        $settings = new Duo\DuoUniversalWordpress\DuoUniversal_Settings($this->duo_utils);
+        $result = $settings->duoup_disable_ca_pinning_validate('on');
+        $this->assertEquals('on', $result);
+    }
+
+    /**
+     * Test that disable CA pinning validate returns 'off' for any other input
+     */
+    public function testDuoDisableCaPinningValidateOff(): void
+    {
+        $settings = new Duo\DuoUniversalWordpress\DuoUniversal_Settings($this->duo_utils);
+        $this->assertEquals('off', $settings->duoup_disable_ca_pinning_validate('off'));
+        $this->assertEquals('off', $settings->duoup_disable_ca_pinning_validate(''));
+        $this->assertEquals('off', $settings->duoup_disable_ca_pinning_validate('invalid'));
     }
 
 }


### PR DESCRIPTION
## Description
Add an admin setting to disable CA pinning and startup logging for CA bundle version and pinning status
- Added "Disable CA Pinning" checkbox to plugin settings (single-site and multisite)
- When enabled, the SDK validates via OS trust store instead of pinned Duo certificates
- Logs CA bundle version at startup
- Logs a warning when CA pinning is disabled

## Motivation and Context
Part of the CA Pinning Standardization effort. This provides a configuration option accessible to WordPress admins

## How Has This Been Tested?
- Unit tests added and passing (./vendor/bin/phpunit tests/)
- Manual testing via Docker WordPress environment:
  - Verified checkbox OFF (default): no "CA pinning is disabled" log, pinning active
  - Verified checkbox ON: "WARNING: CA pinning is disabled via configuration" appears in debug.log
  - Verified toggle works in both directions
  - Verified CA bundle version is logged at startup
  - Verified disable_ca_pinning value reaches the PHP SDK constructor (true/false) via temporary SDK logging
 
## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
